### PR TITLE
位置情報追加時に基本情報が空だった場合のエラーダイアログ作成

### DIFF
--- a/PhotoLocationApp/ AplicationModel/Models/LocationManager.swift
+++ b/PhotoLocationApp/ AplicationModel/Models/LocationManager.swift
@@ -25,4 +25,15 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             coordinate = lastCoordinate
         }
     }
+
+    func isAuthLocation() -> Bool {
+        switch manager.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            return true
+        case .notDetermined,.denied, .restricted:
+            return false
+        @unknown default:
+            fatalError()
+        }
+    }
 }

--- a/PhotoLocationApp/Views/TabContent/AddLocationView.swift
+++ b/PhotoLocationApp/Views/TabContent/AddLocationView.swift
@@ -70,6 +70,8 @@ struct AddLocationView: View {
             }
             .alert("保存エラー", isPresented: $isShowAlert) {
                 // 特に戻すだけなので、処理を行わない
+                // TODO: 位置情報取得権限がありません、保存をする際には有効にしてくださいアラートも出したい
+                // 設定画面に飛ばせたらなおよし
             } message: {
                 Text("名前が空です。名前をつけて保存してください")
             }

--- a/PhotoLocationApp/Views/TabContent/AddLocationView.swift
+++ b/PhotoLocationApp/Views/TabContent/AddLocationView.swift
@@ -19,6 +19,8 @@ struct AddLocationView: View {
     @State private var selectedTime: Int = 0
     @State private var selectedWeather: IdealWeather = .sunny
 
+    @State private var isShowAlert = false
+
     var body: some View {
         VStack {
             HStack {
@@ -46,7 +48,11 @@ struct AddLocationView: View {
             }
 
             Button("位置情報の保存") {
-                if viewModel.name == "" { return }
+                if viewModel.name == "" { 
+                    isShowAlert = true
+                    return
+                }
+                isShowAlert = false
                 guard let latitude = locationManager.coordinate?.coordinate.latitude,
                       let longitude = locationManager.coordinate?.coordinate.longitude else { return }
                 viewModel.latitude = latitude
@@ -61,6 +67,11 @@ struct AddLocationView: View {
                 withAnimation {
                     isAddButtonPressed.toggle()
                 }
+            }
+            .alert("保存エラー", isPresented: $isShowAlert) {
+                // 特に戻すだけなので、処理を行わない
+            } message: {
+                Text("名前が空です。名前をつけて保存してください")
             }
             .padding()
             .background(.blue)

--- a/PhotoLocationApp/Views/TabContent/AddLocationView.swift
+++ b/PhotoLocationApp/Views/TabContent/AddLocationView.swift
@@ -77,9 +77,6 @@ struct AddLocationView: View {
                 }
             }
             .alert("保存エラー", isPresented: $isShowAlert) {
-                // 特に戻すだけなので、処理を行わない
-                // TODO: 位置情報取得権限がありません、保存をする際には有効にしてくださいアラートも出したい
-                // 設定画面に飛ばせたらなおよし
                 if !locationManager.isAuthLocation() {
                     Button("設定画面を開く") {
                         if let url = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(url) {

--- a/PhotoLocationApp/Views/TabContent/AddLocationView.swift
+++ b/PhotoLocationApp/Views/TabContent/AddLocationView.swift
@@ -48,13 +48,21 @@ struct AddLocationView: View {
             }
 
             Button("位置情報の保存") {
-                if viewModel.name == "" { 
+                if !locationManager.isAuthLocation() {
+                    isShowAlert = true
+                    return
+                }
+                if viewModel.name == "" {
                     isShowAlert = true
                     return
                 }
                 isShowAlert = false
                 guard let latitude = locationManager.coordinate?.coordinate.latitude,
-                      let longitude = locationManager.coordinate?.coordinate.longitude else { return }
+                      let longitude = locationManager.coordinate?.coordinate.longitude else { 
+                    isShowAlert = true
+
+                    return
+                }
                 viewModel.latitude = latitude
                 viewModel.longitude = longitude
                 viewModel.saveDate = .now
@@ -72,8 +80,20 @@ struct AddLocationView: View {
                 // 特に戻すだけなので、処理を行わない
                 // TODO: 位置情報取得権限がありません、保存をする際には有効にしてくださいアラートも出したい
                 // 設定画面に飛ばせたらなおよし
+                if !locationManager.isAuthLocation() {
+                    Button("設定画面を開く") {
+                        if let url = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(url) {
+                           UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                        }
+                    }
+                }
+                Button("戻る") {}
             } message: {
-                Text("名前が空です。名前をつけて保存してください")
+                if !locationManager.isAuthLocation() {
+                    Text("設定画面で位置情報を有効にしてください")
+                } else {
+                    Text("名前が空です。名前をつけて保存してください")
+                }
             }
             .padding()
             .background(.blue)


### PR DESCRIPTION
## やること

位置情報追加時に基本情報が空だった場合のエラーダイアログ作成

## 実装方法

追加ボタンを押した際に、基本情報が空だった場合にエラーダイアログを出す